### PR TITLE
Issue 10/config argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 * Source code hosted in Github
 * Planned first (pre)release 0.0.1 available in Pypi @1.11.2018
 
+## Configuration ##
+
+Configure path to test data configuration file to `TEST_DATA_CONFIG` variable in `source/config.py`.
+
 ## Running ##
 
 ```

--- a/source/config.py
+++ b/source/config.py
@@ -1,0 +1,1 @@
+TEST_DATA_CONFIG = '/path/to/test/data/configuration/file'

--- a/source/config.py
+++ b/source/config.py
@@ -1,1 +1,1 @@
-TEST_DATA_CONFIG = '/path/to/test/data/configuration/file'
+TEST_DATA_CONFIG = "test-data-config-example.txt"

--- a/source/server.py
+++ b/source/server.py
@@ -1,11 +1,27 @@
+import sys
+import os.path
+
 import connexion
+
+
+def set_test_data_items():
+    try:
+        path = app.app.config['TEST_DATA_CONFIG']
+        if not os.path.isfile(os.path.abspath(path)):
+            sys.exit(f'ERROR: {path} defined by TEST_DATA_CONFIG is not a file')
+    except KeyError:
+        sys.exit('ERROR: TEST_DATA_CONFIG variable not defined in config.py')
+    else:
+        # todo: read test data items from file
+        return []
+
 
 app = connexion.App(__name__, specification_dir='./')
 
 app.add_api('swagger.yml')
 
 app.app.config.from_object('config')
-TEST_DATA_CONFIG = app.app.config['TEST_DATA_CONFIG']
+TEST_DATA_ITEMS = set_test_data_items()
 
 
 @app.route('/')

--- a/source/server.py
+++ b/source/server.py
@@ -4,6 +4,9 @@ app = connexion.App(__name__, specification_dir='./')
 
 app.add_api('swagger.yml')
 
+app.app.config.from_object('config')
+TEST_DATA_CONFIG = app.app.config['TEST_DATA_CONFIG']
+
 
 @app.route('/')
 def home():

--- a/test-data-config-example.txt
+++ b/test-data-config-example.txt
@@ -1,0 +1,2 @@
+{"key A1": "value A1", "key B1": "value B1", "key C1": "value C1"}
+{"key A2": "value A2", "key B2": "value B2", "key C2": "value C2"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,36 @@
+import pytest
+
 import server
 
 
-def test__test_data_config_path():
-    assert server.TEST_DATA_CONFIG == '/path/to/test/data/configuration/file'
+@pytest.fixture(scope='function')
+def missing_config_file_setup(request):
+    def teardown():
+        server.app.app.config['TEST_DATA_CONFIG'] = 'test-data-config-example.txt'
+
+    server.app.app.config['TEST_DATA_CONFIG'] = 'dummy-file'
+
+    request.addfinalizer(teardown)
+
+
+@pytest.fixture(scope='function')
+def missing_test_data_config_variable_setup(request):
+    def teardown():
+        server.app.app.config['TEST_DATA_CONFIG'] = 'test-data-config-example.txt'
+
+    server.app.app.config.pop('TEST_DATA_CONFIG')
+    request.addfinalizer(teardown)
+
+
+def test__set_test_data_items__ok():
+    assert server.set_test_data_items() == []
+
+
+def test__set_test_data_items__file_not_found(missing_config_file_setup):
+    with pytest.raises(SystemExit, match=r'^ERROR: dummy-file defined by TEST_DATA_CONFIG is not a file$'):
+        server.set_test_data_items()
+
+
+def test__set_test_data_items__test_data_config_variable_missing(missing_test_data_config_variable_setup):
+    with pytest.raises(SystemExit, match=r'^ERROR: TEST_DATA_CONFIG variable not defined in config.py$'):
+        server.set_test_data_items()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,5 @@
+import server
+
+
+def test__test_data_config_path():
+    assert server.TEST_DATA_CONFIG == '/path/to/test/data/configuration/file'


### PR DESCRIPTION
Implementation is different what defined in original issue.
- config.py: contains TEST_DATA_CONFIG variable to define path to file which contains test data items. 
- config.py is read when server is started.

In other words, configuration user needs to do:
- create a file which contains test data items
- update TEST_DATA_CONFIG value in config.py to point to the test data item config file