### PR TITLE
API versioning added, closes #25

### DIFF
--- a/client/src/components/Testdataview.vue
+++ b/client/src/components/Testdataview.vue
@@ -22,7 +22,7 @@ export default {
         };
     },
     created() {
-        axios.get(`/testdata/all`)
+        axios.get(`/api/v1/testdata`)
             .then(response => (this.testdata = response.data.testdata))
             .catch(error => (this.errors = error))
     }

--- a/server/database.py
+++ b/server/database.py
@@ -30,7 +30,7 @@ def add_testdata_to_db():
     db.session.commit()
 
 
-def get_all_testdata():
+def get_testdata():
     testdata = {}
     for row in db.session.query(TestItem, TestItem.dataset).order_by(TestItem.timestamp).all():
         data = {
@@ -46,7 +46,7 @@ def get_all_testdata():
     return testdata
 
 
-def get_testdata():
+def get_testdata_next():
     item = db.session.query(TestItem, TestItem.dataset).order_by(TestItem.timestamp).first()
     item.TestItem.timestamp = datetime.now()
     db.session.commit()

--- a/server/status.py
+++ b/server/status.py
@@ -1,2 +1,2 @@
-def read():
+def get_status():
     pass

--- a/server/swagger.yml
+++ b/server/swagger.yml
@@ -9,9 +9,9 @@ produces:
   - "application/json"
 
 paths:
-  /status:
+  /api/v1/status:
     get:
-      operationId: "status.read"
+      operationId: "status.get_status"
       tags:
         - "Status"
       summary: "Server status"
@@ -19,31 +19,31 @@ paths:
       responses:
         200:
           description: "Server is running"
-  /testdata:
+  /api/v1/testdata:
     get:
-      operationId: "testdata.read"
+      operationId: "testdata.get_testdata"
       tags:
       - "Testdata"
-      summary: "Get test data"
-      description: "Get data that can be used in test execution"
-      responses:
-        200:
-          description: "Successful request of test data"
-          schema:
-            type: string
-            properties:
-              testdata:
-                type: "string"
-  /testdata/all:
-    get:
-      operationId: "testdata.read_all"
-      tags:
-      - "Testdata/all"
       summary: "Get all test data"
       description: "Get all test data which has been configured. Does not reserve test items for test execution."
       responses:
         200:
           description: "Successful request of all test data"
+          schema:
+            type: string
+            properties:
+              testdata:
+                type: "string"
+  /api/v1/testdata/next:
+    get:
+      operationId: "testdata.get_testdata_next"
+      tags:
+      - "Testdata/next"
+      summary: "Get test data"
+      description: "Get data that can be used in test execution."
+      responses:
+        200:
+          description: "Successful request of test data"
           schema:
             type: string
             properties:

--- a/server/testdata.py
+++ b/server/testdata.py
@@ -8,8 +8,8 @@ import database
 ITEMS = None
 
 
-def read():
-    return {"testdata": database.get_testdata()}
+def get_testdata_next():
+    return {"testdata": database.get_testdata_next()}
 
 
 # todo: to be removed when test data items are set with GUI
@@ -39,5 +39,5 @@ def get_ITEMS():
     return ITEMS
 
 
-def read_all():
-    return {"testdata": database.get_all_testdata()}
+def get_testdata():
+    return {"testdata": database.get_testdata()}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,15 +41,15 @@ def test__index_endpoint(client):
 
 
 def test__status_endpoint(client):
-    response = client.get('/status')
+    response = client.get('/api/v1/status')
     assert response.status_code == 200
 
 
 # todo: test will break when configured from GUI is implemented
-def test__testdata_endpoint(client, create_database_setup):
+def test__testdata_next_endpoint(client, create_database_setup):
     datetimes = (datetime(2018, 1, 1, hour) for hour in range(3, 6))
     with freeze_time(datetimes):
-        response = client.get('/testdata')
+        response = client.get('/api/v1/testdata/next')
         assert response.json == {
             "testdata": {
                 "item": "{'key A1': 'value A1', 'key B1': 'value B1', 'key C1': 'value C1'}",
@@ -58,7 +58,7 @@ def test__testdata_endpoint(client, create_database_setup):
             }
         }
     with freeze_time(datetimes):
-        response = client.get('/testdata')
+        response = client.get('/api/v1/testdata/next')
         assert response.json == {
             "testdata": {
                 "item": "{'key A2': 'value A2', 'key B2': 'value B2', 'key C2': 'value C2'}",
@@ -67,7 +67,7 @@ def test__testdata_endpoint(client, create_database_setup):
             }
         }
     with freeze_time(datetimes):
-        response = client.get('/testdata')
+        response = client.get('/api/v1/testdata/next')
         assert response.json == {
             "testdata": {
                 "item": "{'key A1': 'value A1', 'key B1': 'value B1', 'key C1': 'value C1'}",
@@ -78,11 +78,11 @@ def test__testdata_endpoint(client, create_database_setup):
 
 
 # todo: test will break when configured from GUI is implemented
-def test__testdata_all_endpoint(client, create_database_setup):
+def test__testdata_endpoint(client, create_database_setup):
     # todo: workaround until configuration from GUI is implemented
     datetimes = (datetime(2018, 1, 1, hour) for hour in range(3, 5))
     with freeze_time(datetimes):
-        response = client.get('/testdata')
+        response = client.get('/api/v1/testdata/next')
         assert response.json == {
             "testdata": {
                 "item": "{'key A1': 'value A1', 'key B1': 'value B1', 'key C1': 'value C1'}",
@@ -91,7 +91,7 @@ def test__testdata_all_endpoint(client, create_database_setup):
             }
         }
     with freeze_time(datetimes):
-        response = client.get('/testdata')
+        response = client.get('/api/v1/testdata/next')
         assert response.json == {
             "testdata": {
                 "item": "{'key A2': 'value A2', 'key B2': 'value B2', 'key C2': 'value C2'}",
@@ -101,7 +101,7 @@ def test__testdata_all_endpoint(client, create_database_setup):
         }
     # end of workaround
 
-    response = client.get('/testdata/all')
+    response = client.get('/api/v1/testdata')
     print(response.json)
     assert response.json == {
         "testdata": {


### PR DESCRIPTION
**This is a breaking change!**
- API version: /api/v1/ added at the beginning of endpoint name
- Endpoints renamed
  - Get test data for test execution /testdata -> /api/v1/testdata/next
  - Get all configured test data /testdata/all -> /api/v1/testdata
- Functions renamed