### PR TITLE
Issue 51/dataset datatypes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ COPY    client /client
 WORKDIR /client
 
 RUN     apk add sqlite nodejs nodejs-npm
-RUN     npm install ajv & npm install & npm run build
+RUN     npm install ajv 
+RUN     npm install 
+RUN     npm run build
 
 RUN     rm -rf /client
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ COPY    client /client
 WORKDIR /client
 
 RUN     apk add sqlite nodejs nodejs-npm
-RUN     npm install ajv
-RUN     npm install
-RUN     npm run build
+RUN     npm install ajv & npm install & npm run build
+
 RUN     rm -rf /client
 
 WORKDIR /server

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ COPY    client /client
 WORKDIR /client
 
 RUN     apk add sqlite nodejs nodejs-npm
-RUN     npm install ajv 
-RUN     npm install 
+RUN     npm install ajv
+RUN     npm install
 RUN     npm run build
 
 RUN     rm -rf /client

--- a/client/src/assets/styles/testdataserver.css
+++ b/client/src/assets/styles/testdataserver.css
@@ -150,3 +150,7 @@ textarea {
   visibility: hidden;
   margin-bottom: 20px
 }
+
+.datatype {
+  color: #bd7f0c;
+}

--- a/client/src/components/ModifyDatasets.vue
+++ b/client/src/components/ModifyDatasets.vue
@@ -2,14 +2,14 @@
   <div>
     <div class="config-testdata"> 
       <div class="section-header">Existing datasets</div>
-      <div v-for="dataset in Object.keys(testdata)" v-bind:key="dataset">
+      <div v-for="dataset in testdata" v-bind:key="dataset.dataset">
         <div class="dataset-row">
-          <span class="dataset-name" :class="dataset_ta_class(dataset, 'name')" @click="toggle_dataset(dataset)">{{ dataset }}</span> 
-          <span class="item-modify" :class="dataset_ta_class(dataset, 'delete')" @click="confirm_dataset_delete(dataset)" title="Delete dataset"><font-awesome-icon size="1x" icon="trash-alt"/></span>
+          <span class="dataset-name" :class="dataset_ta_class(dataset.dataset, 'name')" @click="toggle_dataset(dataset.dataset)">{{ dataset.dataset }} <span class="datatype"> - {{ dataset.datatype }}</span></span>  
+          <span class="item-modify" :class="dataset_ta_class(dataset.dataset, 'delete')" @click="confirm_dataset_delete(dataset.dataset)" title="Delete dataset"><font-awesome-icon size="1x" icon="trash-alt"/></span>
         </div>
-        <div class="dataset-item-row" v-for="(item, index) in testdata[dataset]" v-bind:key="item.item" v-bind:style="{ display: openedDatasets[dataset] }">
-          <span class="item-name" :class="item_ta_class(dataset, index, 'name')">{{ item.item }}</span>
-          <span class="item-modify" :class="item_ta_class(dataset, index, 'delete')" @click="confirm_item_delete(dataset, item.item)" title="Delete dataset item"><font-awesome-icon size="1x" icon="trash-alt"/></span>
+        <div class="dataset-item-row" v-for="(item, index) in dataset.items" v-bind:key="item.item" v-bind:style="{ display: openedDatasets[dataset.dataset] }">
+          <span class="item-name" :class="item_ta_class(dataset.dataset, index, 'name')">{{ item.item }}</span>
+          <span class="item-modify" :class="item_ta_class(dataset.dataset, index, 'delete')" @click="confirm_item_delete(dataset.dataset, item.item)" title="Delete dataset item"><font-awesome-icon size="1x" icon="trash-alt"/></span>
         </div>
       </div>
     </div>
@@ -21,15 +21,21 @@
           type="text"
           name="new-dataset"
           id="new-dataset"
-          class="form-field ta_new_dataset_name"
+          class="form-field ta-new-dataset-name"
           required
           v-model="newDataset"
         >
+        <label for="new-dataset">Dataset type</label><br/>
+        <select v-model="datatype" name="new-dataset-datatype">
+          <option disabled value="">Please select one</option>
+          <option value="next">Next</option>
+          <option value="random">Random</option>
+        </select><br/> 
         <label for="new-dataset">Dataset items</label>
         <textarea
           name="items"
           id="new-dataset-items"
-          class="form-control ta_new_dataset_items"
+          class="form-control ta-new-dataset-items"
           placeholder='One item in a line. Example: 
             {"username": "user1", "password": "passwd", "email": "user1@example.com"}
             {"username": "user2", "password": "passwd", "email": "user2@example.com"}'
@@ -37,7 +43,7 @@
           required
           v-model="items"
         ></textarea>
-        <button type="submit" class="btn ta_new_dataset_submit" @click="submitNewDataset">Submit</button>
+        <button type="submit" class="btn ta-new-dataset-submit" @click="submitNewDataset">Submit</button>
       </div>
     </div>
   </div>
@@ -62,6 +68,7 @@ export default {
       testdata: {},
       newDataset: "",
       items: "",
+      datatype: "",
       openedDatasets: {},
       showAddNew: "none",
       errors: [],
@@ -103,7 +110,8 @@ export default {
       axios
         .post("/api/v1/testdata", {
           dataset: this.newDataset,
-          items: itemList
+          items: itemList,
+          datatype: this.datatype
         })
         .then(response => {
           this.newDataset = "";

--- a/client/src/components/ModifyDatasets.vue
+++ b/client/src/components/ModifyDatasets.vue
@@ -4,12 +4,19 @@
       <div class="section-header">Existing datasets</div>
       <div v-for="dataset in testdata" v-bind:key="dataset.dataset">
         <div class="dataset-row">
-          <span class="dataset-name" :class="dataset_ta_class(dataset.dataset, 'name')" @click="toggle_dataset(dataset.dataset)">{{ dataset.dataset }} <span class="datatype"> - {{ dataset.datatype }}</span></span>  
-          <span class="item-modify" :class="dataset_ta_class(dataset.dataset, 'delete')" @click="confirm_dataset_delete(dataset.dataset)" title="Delete dataset"><font-awesome-icon size="1x" icon="trash-alt"/></span>
+          <span class="dataset-name" :class="dataset_ta_class(dataset.dataset, 'name')" @click="toggle_dataset(dataset.dataset)">
+            {{ dataset.dataset }} 
+            <span class="datatype"> - {{ dataset.datatype }}</span>
+          </span>
+          <span class="item-modify" :class="dataset_ta_class(dataset.dataset, 'delete')" @click="confirm_dataset_delete(dataset.dataset)" title="Delete dataset">
+            <font-awesome-icon size="1x" icon="trash-alt"/>
+          </span>
         </div>
         <div class="dataset-item-row" v-for="(item, index) in dataset.items" v-bind:key="item.item" v-bind:style="{ display: openedDatasets[dataset.dataset] }">
           <span class="item-name" :class="item_ta_class(dataset.dataset, index, 'name')">{{ item.item }}</span>
-          <span class="item-modify" :class="item_ta_class(dataset.dataset, index, 'delete')" @click="confirm_item_delete(dataset.dataset, item.item)" title="Delete dataset item"><font-awesome-icon size="1x" icon="trash-alt"/></span>
+          <span class="item-modify" :class="item_ta_class(dataset.dataset, index, 'delete')" @click="confirm_item_delete(dataset.dataset, item.item)" title="Delete dataset item">
+            <font-awesome-icon size="1x" icon="trash-alt"/>
+          </span>
         </div>
       </div>
     </div>
@@ -30,7 +37,7 @@
           <option disabled value="">Please select one</option>
           <option value="next">Next</option>
           <option value="random">Random</option>
-        </select><br/> 
+        </select><br/>
         <label for="new-dataset">Dataset items</label>
         <textarea
           name="items"

--- a/robottests/lib/testdata_api_client.py
+++ b/robottests/lib/testdata_api_client.py
@@ -7,16 +7,18 @@ import requests
 
 class TestdataApi(object):
     @staticmethod
-    def add_dataset(base_url, dataset_name, *dataset_items):
+    def add_dataset(base_url, dataset_name, datatype, dataset_items):
         """
         Add new dataset.
 
         :param base_url: base url for api
         :param dataset_name: name of dataset to be added
+        :param datatype: dataset datatype
         :param dataset_items: items for dataset
         """
         response = requests.post(
-            base_url + '/testdata', json={'dataset': dataset_name, 'items': dataset_items}
+            base_url + '/testdata',
+            json={'dataset': dataset_name, 'items': dataset_items, 'datatype': datatype},
         )
         if response.status_code != 201:
             BuiltIn().fail(
@@ -24,16 +26,6 @@ class TestdataApi(object):
             )
 
         logger.info('New dataset added.')
-
-    def add_multiple_dataset(self, base_url, datasets):
-        """
-        Add multiple dataset.
-
-        :param base_url: base url for api
-        :param datasets: dict of datasets and their items in a list
-        """
-        for dataset, items in datasets.items():
-            self.add_dataset(base_url, dataset, *items)
 
     @staticmethod
     def delete_dataset(base_url, dataset_name):
@@ -57,8 +49,8 @@ class TestdataApi(object):
         :param base_url: base url for api
         """
         response = requests.get(base_url + '/testdata')
-        for dataset in response.json()['testdata']:
-            self.delete_dataset(base_url, dataset)
+        for index in range(len(response.json()['testdata'])):
+            self.delete_dataset(base_url, response.json()['testdata'][index]['dataset'])
 
     @staticmethod
     def send_get_request(url):
@@ -80,9 +72,7 @@ class TestdataApi(object):
         :rtype: requests.Response
         """
         return requests.post(
-            url,
-            json=json.loads(body_json),
-            headers={'Content-Type': 'application/json'},
+            url, json=json.loads(body_json), headers={'Content-Type': 'application/json'}
         )
 
     @staticmethod

--- a/robottests/lib/verify.py
+++ b/robottests/lib/verify.py
@@ -11,7 +11,9 @@ class Verify(object):
                 'Getting testdata failed ({}: {})'.format(response.status_code, response.text)
             )
 
-        return [items['item'] for items in response.json()['testdata'][dataset_name]]
+        for dataset in response.json()['testdata']:
+            if dataset['dataset'] == dataset_name:
+                return [items['item'] for items in dataset['items']]
 
     def verify_new_dataset(self, base_url, dataset_name, items):
         """
@@ -25,7 +27,7 @@ class Verify(object):
 
         for item in items.splitlines():
             if item not in db_item_list:
-                BuiltIn().fail('Expected dataset item ({}}) not found in database'.format(item))
+                BuiltIn().fail('Expected dataset item ({}) not found in database'.format(item))
 
         logger.info('New dataset verified.')
 
@@ -84,9 +86,15 @@ class Verify(object):
                 'Unexpected status code! Expected: 200, actual: {}'.format(response.status_code)
             )
 
-        response_datasets = {}
-        for dataset, items in response.json()['testdata'].items():
-            response_datasets[dataset] = [item['item'] for item in items]
+        response_datasets = []
+        for dataset in response.json()['testdata']:
+            response_datasets.append(
+                {
+                    'dataset': dataset['dataset'],
+                    'datatype': dataset['datatype'],
+                    'items': [item['item'] for item in dataset['items']],
+                }
+            )
 
         if datasets != response_datasets:
             BuiltIn().fail(

--- a/robottests/resources/api/given.robot
+++ b/robottests/resources/api/given.robot
@@ -1,10 +1,13 @@
 *** Keywords ***
 dataset item was requested
-    ${response}=    send get request    ${API_URL}/testdata/${DATASET_NAMES}[0]
+    ${response}=    send get request    ${API_URL}/testdata/${DATASET_NAME}
     Set Test Variable    ${PREVIOUS_RESPONSE}    ${response}
 
 service was running
     Log    Service is already running after setup
 
 testdata was configured
-    add multiple dataset    ${API_URL}    ${DATASETS}
+    add dataset    ${API_URL}                     &{NEXT_DATASET}[dataset]      
+    ...            &{NEXT_DATASET}[datatype]      &{NEXT_DATASET}[items]
+    add dataset    ${API_URL}                     &{RANDOM_DATASET}[dataset]      
+    ...            &{RANDOM_DATASET}[datatype]    &{RANDOM_DATASET}[items]

--- a/robottests/resources/api/given.robot
+++ b/robottests/resources/api/given.robot
@@ -7,7 +7,7 @@ service was running
     Log    Service is already running after setup
 
 testdata was configured
-    add dataset    ${API_URL}                     &{NEXT_DATASET}[dataset]      
+    add dataset    ${API_URL}                     &{NEXT_DATASET}[dataset]
     ...            &{NEXT_DATASET}[datatype]      &{NEXT_DATASET}[items]
-    add dataset    ${API_URL}                     &{RANDOM_DATASET}[dataset]      
+    add dataset    ${API_URL}                     &{RANDOM_DATASET}[dataset]
     ...            &{RANDOM_DATASET}[datatype]    &{RANDOM_DATASET}[items]

--- a/robottests/resources/api/then.robot
+++ b/robottests/resources/api/then.robot
@@ -1,11 +1,15 @@
 *** Keywords ***
 status code 200 with datasets will be received
-    verify get testdata response    ${RESPONSE}    ${DATASETS}
+    verify get testdata response    ${RESPONSE}    ${ALL_DATASETS}
 
 status code 200 with next dataset item will be received
-    ${dataset_name}=    Set Variable    ${DATASET_NAMES}[0]
-    ${items}=           Set Variable    &{DATASETS}[${dataset_name}]
+    ${dataset_name}=    Set Variable    ${DATASET_NAME}
+    ${items}=           Set Variable    &{NEXT_DATASET}[items]
     verify get testdata dataset response    ${items}[1]    ${PREVIOUS_RESPONSE}    ${RESPONSE}
+
+status code 200 with random dataset item will be received
+    Should Be Equal As Numbers    ${RESPONSE.status_code}    200
+    Should Be True                ${RESPONSE.json()}[testdata]
 
 status code "${code}" will be received
     Should Be Equal As Numbers    ${RESPONSE.status_code}    ${code}

--- a/robottests/resources/e2e/aliases.py
+++ b/robottests/resources/e2e/aliases.py
@@ -21,9 +21,10 @@ PAGE_ELEMENT = {
 
 ADD_NEW_DATASET = {
     'header': 'css=#add-new-dataset-header',
-    'name': 'css=.ta_new_dataset_name',
-    'items': 'css=.ta_new_dataset_items',
-    'submit': 'css=.ta_new_dataset_submit',
+    'name': 'css=.ta-new-dataset-name',
+    'datatype': 'name=new-dataset-datatype',
+    'items': 'css=.ta-new-dataset-items',
+    'submit': 'css=.ta-new-dataset-submit',
 }
 
 ALERT_TEXT = {

--- a/robottests/resources/e2e/given.robot
+++ b/robottests/resources/e2e/given.robot
@@ -4,12 +4,13 @@ add new dataset section was open
     Click Element    &{ADD_NEW_DATASET}[header]
     Wait Until Element Is Visible    &{ADD_NEW_DATASET}[submit]
 
-dataset was configured
-    add dataset    ${API_URL}    ${DATASET_NAME}    @{ITEMS}    
-    Go To    ${BASE_URL}&{ON_PAGE}[configuration page]
 
 user was not on "${page}"
     Go To    ${BASE_URL}&{NOT_ON_PAGE}[${page}]
 
 user was on "${page}"
     Go To    ${BASE_URL}&{ON_PAGE}[${page}]
+
+"${datatype}" dataset was configured
+    add dataset    ${API_URL}    ${DATASET_NAME}    ${datatype}    ${ITEMS}
+    Go To    ${BASE_URL}&{ON_PAGE}[configuration page]

--- a/robottests/resources/e2e/when.robot
+++ b/robottests/resources/e2e/when.robot
@@ -24,10 +24,11 @@ user confirms deleting
 user goes to root domain
     Go To     ${BASE_URL}
 
-user submits new dataset
+user submits new "${datatype}" dataset
     Set Test Variable    ${ACTION}    dataset-added
     Set Test Variable    ${DATASET_ITEMS}    ${ITEMS}[0]\n${ITEMS}[1]
     Input Text    &{ADD_NEW_DATASET}[name]    ${DATASET_NAME}
+    Select From List By Value    &{ADD_NEW_DATASET}[datatype]    ${datatype}
     Input Text    &{ADD_NEW_DATASET}[items]    ${DATASET_ITEMS}
     Click Button    &{ADD_NEW_DATASET}[submit]
     Wait Until Element Does Not Contain    &{ADD_NEW_DATASET}[name]    ${DATASET_NAME} 

--- a/robottests/tests/api/testdata-dataset.robot
+++ b/robottests/tests/api/testdata-dataset.robot
@@ -13,14 +13,14 @@ Resource         ../../resources/api/generic-resources.robot
 @{ALL_DATASETS}=      &{NEXT_DATASET}    &{RANDOM_DATASET}
 
 *** Test Cases ***
-Next - GET /testdata/<dataset> will response with status code 200 and next dataset item 
+Next - GET /testdata/<dataset> will response with status code 200 and next dataset item
     [Setup]    Set Test Variable    ${DATASET_NAME}    ${DATASET_NAMES}[0]
     Given testdata was configured
     And dataset item was requested
     When GET /testdata/<dataset> request is send
-    Then status code 200 with next dataset item will be received    
+    Then status code 200 with next dataset item will be received
 
-Random - GET /testdata/<dataset> will response with status code 200 and random dataset item 
+Random - GET /testdata/<dataset> will response with status code 200 and random dataset item
     [Setup]    Set Test Variable    ${DATASET_NAME}    ${DATASET_NAMES}[1]
     Given testdata was configured
     When GET /testdata/<dataset> request is send

--- a/robottests/tests/api/testdata-dataset.robot
+++ b/robottests/tests/api/testdata-dataset.robot
@@ -3,20 +3,28 @@ Test Teardown    Delete dataset case teardown
 Resource         ../../resources/api/generic-resources.robot
 
 *** Variables ***
-@{DATASET_NAMES}=    dataset-1    dataset-2
-@{ITEMS_0}=          {"key-a1": "value-a1", "key-a2": "value-a2"}
-...                  {"key-b1": "value-b1", "key-b2": "value-b2"}
-@{ITEMS_1}=          {"key-z1": "value-z1", "key-z2": "value-z2"}
-...                  {"key-x1": "value-x1", "key-x2": "value-x2"}
-&{DATASETS}=         ${DATASET_NAMES}[0]=@{ITEMS_0}    ${DATASET_NAMES}[1]=@{ITEMS_1}
+@{DATASET_NAMES}=     dataset-1    dataset-2
+@{ITEMS_0}=           {"key-a1": "value-a1", "key-a2": "value-a2"}
+...                   {"key-b1": "value-b1", "key-b2": "value-b2"}
+@{ITEMS_1}=           {"key-z1": "value-z1", "key-z2": "value-z2"}
+...                   {"key-x1": "value-x1", "key-x2": "value-x2"}
+&{NEXT_DATASET}=      dataset=${DATASET_NAMES}[0]    datatype=next      items=@{ITEMS_0}
+&{RANDOM_DATASET}=    dataset=${DATASET_NAMES}[1]    datatype=random    items=@{ITEMS_1}
+@{ALL_DATASETS}=      &{NEXT_DATASET}    &{RANDOM_DATASET}
 
 *** Test Cases ***
-GET /testdata/<dataset> will response with status code 200 and next dataset item 
+Next - GET /testdata/<dataset> will response with status code 200 and next dataset item 
     [Setup]    Set Test Variable    ${DATASET_NAME}    ${DATASET_NAMES}[0]
     Given testdata was configured
     And dataset item was requested
     When GET /testdata/<dataset> request is send
-    Then status code 200 with next dataset item will be received
+    Then status code 200 with next dataset item will be received    
+
+Random - GET /testdata/<dataset> will response with status code 200 and random dataset item 
+    [Setup]    Set Test Variable    ${DATASET_NAME}    ${DATASET_NAMES}[1]
+    Given testdata was configured
+    When GET /testdata/<dataset> request is send
+    Then status code 200 with random dataset item will be received
 
 Unknown dataset - GET /testdata/<dataset> will response with status code 404
     [Setup]    Set Test Variable    ${DATASET_NAME}    unknown

--- a/robottests/tests/api/testdata.robot
+++ b/robottests/tests/api/testdata.robot
@@ -45,14 +45,14 @@ Missing items parameter - POST /testdata will response with status code 400
     Then status code "400" will be received with error "'items' is a required property" 
 
 Missing datatype parameter - POST /testdata will response with status code 400
-    [Setup]    Set Test Variable    
+    [Setup]    Set Test Variable
     ...    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]", "items": [${ITEMS_0}[0], ${ITEMS_0}[1]]}
     Given service was running
     When POST /testdata request without datatype parameter is send
-    Then status code "400" will be received with error "'datatype' is a required property" 
+    Then status code "400" will be received with error "'datatype' is a required property"
 
 Unsupported datatype parameter - POST /testdata will response with status code 400
-    [Setup]    Set Test Variable    
+    [Setup]    Set Test Variable
     ...    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]", "items": [${ITEMS_0}[0], ${ITEMS_0}[1]], "datatype": "unsupported"}
     Given service was running
     When POST /testdata request with unsupported datatype parameter is send

--- a/robottests/tests/api/testdata.robot
+++ b/robottests/tests/api/testdata.robot
@@ -8,8 +8,10 @@ Resource         ../../resources/api/generic-resources.robot
 ...                  {"key-b1": "value-b1", "key-b2": "value-b2"}
 @{ITEMS_1}=          {"key-z1": "value-z1", "key-z2": "value-z2"}
 ...                  {"key-x1": "value-x1", "key-x2": "value-x2"}
-&{DATASETS}=         ${DATASET_NAMES}[0]=@{ITEMS_0}    ${DATASET_NAMES}[1]=@{ITEMS_1}
-
+&{NEXT_DATASET}=      dataset=${DATASET_NAMES}[0]    datatype=next     items=@{ITEMS_0}
+&{RANDOM_DATASET}=    dataset=${DATASET_NAMES}[1]    datatype=random    items=@{ITEMS_1}
+@{ALL_DATASETS}=      &{NEXT_DATASET}    &{RANDOM_DATASET}
+# [{'dataset': 'dataset-1', 'datatype': 'next', 'items': ['...']}]
 *** Test Cases ***
 GET /testdata will response with status code 200 and datasets
     Given testdata was configured
@@ -18,26 +20,40 @@ GET /testdata will response with status code 200 and datasets
 
 POST /testdata with dataset will response with status code 201
     [Setup]    Set Test Variable    
-     ...    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]", "items": [${ITEMS_0}[0], ${ITEMS_0}[1]]}
+     ...    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]", "items": [${ITEMS_0}[0], ${ITEMS_0}[1]], "datatype": "next"}
     Given service was running
     When POST /testdata request with dataset is send
     Then status code "201" will be received
 
 Missing dataset parameter - POST /testdata will response with status code 400
-    [Setup]    Set Test Variable    ${PARAMS}    {"items": [${ITEMS_0}[0], ${ITEMS_0}[1]]}
+    [Setup]    Set Test Variable    ${PARAMS}    {"items": [${ITEMS_0}[0], ${ITEMS_0}[1]], "datatype": "next"}
     Given service was running
     When POST /testdata request without dataset parameter is send
     Then status code "400" will be received with error "'dataset' is a required property" 
 
 Existing dataset - POST /testdata with dataset will response with status code 409
     [Setup]    Set Test Variable    
-     ...    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]", "items": [${ITEMS_0}[0], ${ITEMS_0}[1]]}
+     ...    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]", "items": [${ITEMS_0}[0], ${ITEMS_0}[1]], "datatype": "next"}
     Given testdata was configured
     When POST /testdata request with existing dataset is send
     Then status code "409" will be received with error "dataset exists already" 
 
 Missing items parameter - POST /testdata will response with status code 400
-    [Setup]    Set Test Variable    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]"}
+    [Setup]    Set Test Variable    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]", "datatype": "next"}
     Given service was running
     When POST /testdata request without dataset parameter is send
     Then status code "400" will be received with error "'items' is a required property" 
+
+Missing datatype parameter - POST /testdata will response with status code 400
+    [Setup]    Set Test Variable    
+    ...    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]", "items": [${ITEMS_0}[0], ${ITEMS_0}[1]]}
+    Given service was running
+    When POST /testdata request without datatype parameter is send
+    Then status code "400" will be received with error "'datatype' is a required property" 
+
+Unsupported datatype parameter - POST /testdata will response with status code 400
+    [Setup]    Set Test Variable    
+    ...    ${PARAMS}    {"dataset": "${DATASET_NAMES}[0]", "items": [${ITEMS_0}[0], ${ITEMS_0}[1]], "datatype": "unsupported"}
+    Given service was running
+    When POST /testdata request with unsupported datatype parameter is send
+    Then status code "400" will be received with error "unsupported 'datatype'"

--- a/robottests/tests/e2e/configuration-notification.robot
+++ b/robottests/tests/e2e/configuration-notification.robot
@@ -10,36 +10,36 @@ ${DATASET_NAME}    dataset-1
 *** Test Cases ***
 Add new dataset - Ok - Notification will be shown
     Given add new dataset section was open
-    When user submits new dataset
+    When user submits new "next" dataset
     Then "ok" notification will be shown
 
 Add new dataset - Error - Notification will be shown
-    Given dataset was configured
+    Given "next" dataset was configured
     And add new dataset section was open
-    When user submits new dataset
+    When user submits new "next" dataset
     Then "error" notification will be shown
 
 Delete dataset - Ok - Notification will be shown
-    Given dataset was configured
+    Given "next" dataset was configured
     When user clicks dataset delete button
     And user confirms deleting
     Then "ok" notification will be shown
 
 Delete item - Ok - Notification will be shown
-    Given dataset was configured
+    Given "next" dataset was configured
     When user clicks dataset item delete button
     And user confirms deleting
     Then "ok" notification will be shown
     
 Ok notification will be shown and hidden
     Given add new dataset section was open
-    When user submits new dataset
+    When user submits new "next" dataset
     Then "ok" notification will be shown
     And notification will be hidden
 
 Error notification will be shown and not hidden
-    Given dataset was configured
+    Given "next" dataset was configured
     And add new dataset section was open
-    When user submits new dataset
+    When user submits new "next" dataset
     Then "error" notification will be shown
     And notification will stay visible

--- a/robottests/tests/e2e/configuration.robot
+++ b/robottests/tests/e2e/configuration.robot
@@ -8,48 +8,53 @@ ${DATASET_NAME}    dataset-1
 ...                {"key-b1": "value-b1", "key-b2": "value-b2"}
 
 *** Test Cases ***
-New dataset will be stored to database
+Next datatype - New dataset will be stored to database
     Given add new dataset section was open
-    When user submits new dataset
+    When user submits new "next" dataset
+    Then dataset will be stored to database
+
+Random datatype - New dataset will be stored to database
+    Given add new dataset section was open
+    When user submits new "random" dataset
     Then dataset will be stored to database
 
 New dataset will be added to existing dataset list
     Given add new dataset section was open
-    When user submits new dataset
+    When user submits new "next" dataset
     Then dataset will be added to existing dataset list
 
 Deleting dataset will show alert for conformation
-    Given dataset was configured
+    Given "next" dataset was configured
     When user clicks dataset delete button
     Then conformation alert for dataset with information will be shown
     [Teardown]    Sleep    0.1    reason=To prevent next case to be started too soon
 
 Delete dataset will remove dataset from database
-    Given dataset was configured
+    Given "next" dataset was configured
     When user clicks dataset delete button
     And user confirms deleting
     Then dataset will be removed from database
 
 Delete dataset will remove dataset from existing dataset list
-    Given dataset was configured
+    Given "next" dataset was configured
     When user clicks dataset delete button
     And user confirms deleting
     Then dataset will be removed from existing dataset list
 
 Deleting dataset item will show alert for conformation
-    Given dataset was configured
+    Given "next" dataset was configured
     When user clicks dataset item delete button
     Then conformation alert for item with information will be shown
 
 Delete dataset item will remove dataset from database
-    Given dataset was configured
+    Given "next" dataset was configured
     When user clicks dataset item delete button
     And user confirms deleting
     Then dataset item will be removed from database
     And other dataset items will be left in database
     
 Delete dataset item will remove dataset from existing dataset list
-    Given dataset was configured
+    Given "next" dataset was configured
     When user clicks dataset item delete button
     And user confirms deleting
     Then dataset item will be removed from existing dataset list

--- a/server/database.py
+++ b/server/database.py
@@ -1,8 +1,10 @@
 import os.path
 from datetime import datetime
 
+from sqlalchemy import func
+
 from config import db
-from models import TestItem
+from models import Item, Dataset
 
 
 def setup():
@@ -18,51 +20,75 @@ def create():
 
 
 def get_testdata():
-    testdata = {}
-    for row in db.session.query(TestItem, TestItem.dataset).order_by(TestItem.timestamp).all():
-        data = {
-            'item': row.TestItem.item,
-            'status': row.TestItem.status,
-            'timestamp': row.TestItem.timestamp,
-        }
-        if row.TestItem.dataset not in testdata:
-            testdata[row.TestItem.dataset] = [data]
-        else:
-            testdata[row.TestItem.dataset].append(data)
+    testdata = []
+    for row_d in db.session.query(Dataset, Dataset.name).all():
+        items = []
+        for row in (
+            db.session.query(Item, Item.dataset_name)
+            .filter(Item.dataset_name == row_d.Dataset.name)
+            .order_by(Item.timestamp)
+            .all()
+        ):
+            items.append(
+                {'item': row.Item.item, 'status': row.Item.status, 'timestamp': row.Item.timestamp}
+            )
+        testdata.append(
+            {'dataset': row_d.Dataset.name, 'datatype': row_d.Dataset.datatype, 'items': items}
+        )
 
     return testdata
 
 
 def get_testdata_next(dataset):
-    count = db.session.query(TestItem, TestItem.dataset).filter(TestItem.dataset == dataset).all()
-    if len(count) == 0:
-        return 'does not exist'
-
-    item = (
-        db.session.query(TestItem, TestItem.dataset)
-        .filter(TestItem.dataset == dataset)
-        .order_by(TestItem.timestamp)
+    rows = (
+        db.session.query(Dataset, Dataset.name, Dataset.datatype)
+        .filter(Dataset.name == dataset)
         .first()
     )
-    item.TestItem.timestamp = datetime.now()
-    db.session.commit()
-    return {
-        'item': item.TestItem.item,
-        'status': item.TestItem.status,
-        'timestamp': item.TestItem.timestamp,
-    }
+    if not rows:
+        return 'does not exist'
+
+    if rows.datatype == 'next':
+        item = (
+            db.session.query(Item, Item.dataset_name)
+            .filter(Item.dataset_name == dataset)
+            .order_by(Item.timestamp)
+            .first()
+        )
+        item.Item.timestamp = datetime.now()
+        db.session.commit()
+        return {
+            'item': item.Item.item,
+            'status': item.Item.status,
+            'timestamp': item.Item.timestamp,
+        }
+    elif rows.datatype == 'random':
+        item = (
+            db.session.query(Item, Item.dataset)
+            .filter(Item.dataset_name == dataset)
+            .order_by(func.random())
+            .first()
+        )
+        return {
+            'item': item.Item.item,
+            'status': item.Item.status,
+            'timestamp': item.Item.timestamp,
+        }
 
 
-def add_testdata_to_db(dataset, items):
-    count = db.session.query(TestItem, TestItem.dataset).filter(TestItem.dataset == dataset).all()
+def add_testdata_to_db(dataset, items, datatype):
+    count = db.session.query(Dataset, Dataset.name).filter(Dataset.name == dataset).all()
     if len(count) > 0:
         return 'exists'
 
+    new_dataset = Dataset(name=dataset, datatype=datatype)
     for item in items:
-        testitem = TestItem(
-            dataset=dataset, item=str(item), status='available', timestamp=datetime.now()
+        testitem = Item(
+            dataset_name=dataset, item=str(item), status='available', timestamp=datetime.now()
         )
+        new_dataset.items.append(testitem)
         db.session.add(testitem)
+    db.session.add(new_dataset)
     db.session.commit()
     return 'added'
 
@@ -75,15 +101,17 @@ def _delete_testdata_data(count):
 
 
 def delete_dataset(dataset):
-    count = db.session.query(TestItem.dataset).filter(TestItem.dataset == dataset).delete()
+    count = db.session.query(Item.dataset_name).filter(Item.dataset_name == dataset).delete()
+    _delete_testdata_data(count)
+    count = db.session.query(Dataset.name).filter(Dataset.name == dataset).delete()
     return _delete_testdata_data(count)
 
 
 def delete_dataset_item(dataset, item):
     count = (
-        db.session.query(TestItem.item)
-        .filter(TestItem.item == item)
-        .filter(TestItem.dataset == dataset)
+        db.session.query(Item.item)
+        .filter(Item.item == item)
+        .filter(Item.dataset_name == dataset)
         .delete()
     )
     return _delete_testdata_data(count)

--- a/server/models.py
+++ b/server/models.py
@@ -3,18 +3,34 @@ from datetime import datetime
 from config import db, ma
 
 
-class TestItem(db.Model):
+class Item(db.Model):
 
-    __tablename__ = 'testitem'
+    __tablename__ = 'item'
 
-    dataset = db.Column(db.String(32), primary_key=True)
     item = db.Column(db.String(100), primary_key=True)
-    status = db.Column(db.String(15))
+    status = db.Column(db.String(15), nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    dataset_name = db.Column(db.String(32), db.ForeignKey('dataset.name'), nullable=False, primary_key=True)
 
 
-class TestItemSchema(ma.ModelSchema):
+class ItemSchema(ma.ModelSchema):
     class Meta:
 
-        model = TestItem
+        model = Item
+        sqla_session = db.session
+
+
+class Dataset(db.Model):
+
+    __tablename__ = 'dataset'
+
+    name = db.Column(db.String(32), primary_key=True)
+    datatype = db.Column(db.String(15), nullable=False)
+    items = db.relationship('Item', backref='dataset', lazy=True)
+
+
+class DatasetSchema(ma.ModelSchema):
+    class Meta:
+
+        model = Dataset
         sqla_session = db.session

--- a/server/models.py
+++ b/server/models.py
@@ -10,7 +10,9 @@ class Item(db.Model):
     item = db.Column(db.String(100), primary_key=True)
     status = db.Column(db.String(15), nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-    dataset_name = db.Column(db.String(32), db.ForeignKey('dataset.name'), nullable=False, primary_key=True)
+    dataset_name = db.Column(
+        db.String(32), db.ForeignKey('dataset.name'), nullable=False, primary_key=True
+    )
 
 
 class ItemSchema(ma.ModelSchema):

--- a/server/swagger.yml
+++ b/server/swagger.yml
@@ -49,6 +49,7 @@ paths:
               required:
                 - dataset
                 - items
+                - datatype
               properties:
                 dataset:
                   type: string
@@ -56,6 +57,9 @@ paths:
                 items:
                   type: array
                   description: Items for dataset
+                datatype:
+                  type: string
+                  description: Dataset type. Supported values - next, random
       responses:
         201:
           description: "Successfully created dataset."

--- a/server/testdata.py
+++ b/server/testdata.py
@@ -21,7 +21,19 @@ def get_testdata():
 
 
 def post_dataset(body):
-    status = database.add_testdata_to_db(body.get('dataset').strip(), body.get('items'))
+    if body.get('datatype') not in ['next', 'random']:
+        return (
+            {
+                'detail': "unsupported 'datatype'",
+                'status': 400,
+                'title': 'Bad Request',
+                'type': 'about:blank',
+            },
+            400,
+        )
+    status = database.add_testdata_to_db(
+        body.get('dataset').strip(), body.get('items'), body.get('datatype')
+    )
     if status == 'added':
         return '', 201
     elif status == 'exists':


### PR DESCRIPTION
Support for `next` and `random` datatypes added.

- Parameters for POST /api/v1/testdata are now:
  - dataset
  - items
  - datatype

**Database is not migrated. Existing database needs to be deleted.**

`testdata.py` and `database.py` are quite messy which should be refactored later.